### PR TITLE
Problem: IPMVAL-964 (no asset credential allowed for the mass manager)

### DIFF
--- a/src/configuration.json
+++ b/src/configuration.json
@@ -6,13 +6,13 @@
 		},
 		{
 			"usage_id": "mass_device_management",
-			"supported_types": [ "Snmpv3" ]							
+			"supported_types": [ "UserAndPassword" ]							
 		}
 	],
     "consumers": [
 		{
 			"client_regex": ".*",
-			"usages": [ "discovery_monitoring" ]							
+			"usages": [ "discovery_monitoring", "mass_device_management" ]							
 		}
 	],
 	"producers": [

--- a/src/fty-security-wallet.conf
+++ b/src/fty-security-wallet.conf
@@ -1,3 +1,3 @@
 # Create directory for fty-security-wallet
-d /var/lib/fty/fty-security-wallet/ 0600 bios root
+d /var/lib/fty/fty-security-wallet/ 0700 bios root
 x /var/lib/fty/fty-security-wallet/*


### PR DESCRIPTION
fixed configuration.json + fty-security-wallet.conf
Signed-off-by: Degott, Francois Regis <FrancoisRegisDegott@eaton.com>