### PR TITLE
Fixed clang compilation

### DIFF
--- a/src/cam_credential_asset_mapping.cc
+++ b/src/cam_credential_asset_mapping.cc
@@ -45,7 +45,7 @@ namespace cam
     si.addMember(PROTOCOL_ENTRY) <<= m_protocol;
     si.addMember(PORT_ENTRY) <<= m_port;
     si.addMember(CREDENTIAL_ID_ENTRY) <<= m_credentialId;
-    si.addMember(CREDENTIAL_STATUS_ENTRY) <<= m_status;
+    si.addMember(CREDENTIAL_STATUS_ENTRY) <<= uint8_t(m_status);
     si.addMember(EXTENDED_INFO_ENTRY) <<= m_extendedInfo;
   }
 

--- a/src/cam_exception.cc
+++ b/src/cam_exception.cc
@@ -98,7 +98,7 @@ namespace cam
 
     void operator<<= (cxxtools::SerializationInfo& si, const CamException & exception)
     {
-        si.addMember("errorCode") <<= exception.m_code;
+        si.addMember("errorCode") <<= uint8_t(exception.m_code);
         si.addMember("whatArg") <<= exception.m_whatArg;
         exception.fillSerializationInfo(si.addMember("extraData"));
     }

--- a/src/secw_exception.cc
+++ b/src/secw_exception.cc
@@ -106,7 +106,7 @@ namespace secw
 
     void operator<<= (cxxtools::SerializationInfo& si, const SecwException & exception)
     {
-        si.addMember("errorCode") <<= exception.m_code;
+        si.addMember("errorCode") <<= uint8_t(exception.m_code);
         si.addMember("whatArg") <<= exception.m_whatArg;
         exception.fillSerializationInfo(si.addMember("extraData"));
     }

--- a/src/secw_snmpv3.cc
+++ b/src/secw_snmpv3.cc
@@ -111,10 +111,10 @@ namespace secw
 
     void Snmpv3::fillSerializationInfoPublicDoc(cxxtools::SerializationInfo& si) const
     {
-        si.addMember(DOC_SNMPV3_SECURITY_LEVEL) <<= m_securityLevel;
+        si.addMember(DOC_SNMPV3_SECURITY_LEVEL) <<= uint8_t(m_securityLevel);
         si.addMember(DOC_SNMPV3_SECURITY_NAME) <<= m_securityName;
-        si.addMember(DOC_SNMPV3_AUTH_PROTOCOL) <<= m_authProtocol;
-        si.addMember(DOC_SNMPV3_PRIV_PROTOCOL) <<= m_privProtocol;
+        si.addMember(DOC_SNMPV3_AUTH_PROTOCOL) <<= uint8_t(m_authProtocol);
+        si.addMember(DOC_SNMPV3_PRIV_PROTOCOL) <<= uint8_t(m_privProtocol);
     }
 
     void Snmpv3::updatePrivateDocFromSerializationInfo(const cxxtools::SerializationInfo& si)


### PR DESCRIPTION
Fixed clang compilation. But better way is upgrade cxxtools, which have enum serializations routine.