### PR TITLE
Fix systemd deps for consumers of Unix socket

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1,0 +1,78 @@
+# Customized (manually maintained) bits of configure.ac for fty-warranty
+
+AC_DEFUN([AX_PROJECT_LOCAL_HOOK], [
+    AC_MSG_WARN([Running the PROJECT_LOCAL_HOOK])
+
+    AC_ARG_WITH([socketSecurityWallet],
+        [AS_HELP_STRING([--with-socketSecurityWallet=PATH], [Filename of fty-security-wallet service Unix socket])],,
+        [with_socketSecurityWallet=/run/fty-security-wallet/secw.socket])
+    AC_SUBST([socketSecurityWallet], [$with_socketSecurityWallet])
+    AC_SUBST([socketSecurityWalletDir], [`dirname $with_socketSecurityWallet`])
+
+])
+
+AC_DEFUN([AX_PROJECT_LOCAL_HOOK_CONFIGVARS], [
+    # Note: DO NOT refer to complete token name of this routine in the
+    # message below, or you would get an infinite loop in m4 autoconf ;)
+    AC_MSG_WARN([Running the PROJECT_LOCAL_HOOK_CONFIGVARS])
+
+    ### Customization follows, to avoid verbatim '${prefix}' in generated files:
+    dnl expand ${sysconfdir} and write it out
+    conftemp="${sysconfdir}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    CONFPATH=${conftemp}
+    AC_DEFINE_UNQUOTED(CONFPATH, "${conftemp}", [Default path for configuration files])
+    AC_SUBST(CONFPATH)
+
+    dnl same for datadir
+    conftemp="${datadir}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    DATADIR=${conftemp}
+    AC_DEFINE_UNQUOTED(DATADIR, "${conftemp}", [Default path for data files])
+    AC_SUBST(DATADIR)
+
+    dnl same for bindir
+    conftemp="${bindir}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    BINDIR=${conftemp}
+    AC_DEFINE_UNQUOTED(BINDIR, "${conftemp}", [Default path for user executables])
+    AC_SUBST(BINDIR)
+
+    dnl same for sbindir
+    conftemp="${sbindir}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    SBINDIR=${conftemp}
+    AC_DEFINE_UNQUOTED(SBINDIR, "${conftemp}", [Default path for system executables])
+    AC_SUBST(SBINDIR)
+
+    dnl same for libdir
+    conftemp="${libdir}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    LIBDIR=${conftemp}
+    AC_DEFINE_UNQUOTED(LIBDIR, "${conftemp}", [Default path for system libraries])
+    AC_SUBST(LIBDIR)
+
+    dnl same for libexecdir
+    conftemp="${libexecdir}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    LIBEXECDIR=${conftemp}
+    AC_DEFINE_UNQUOTED(LIBEXECDIR, "${conftemp}", [Default path for system libraries - executable helpers])
+    AC_SUBST(LIBEXECDIR)
+
+    dnl same for prefix
+    conftemp="${prefix}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    PREFIXDIR=${conftemp}
+    AC_DEFINE_UNQUOTED(PREFIXDIR, "${conftemp}", [Default root path for component])
+    AC_SUBST(PREFIXDIR)
+
+    eval socketSecurityWallet=$socketSecurityWallet
+    eval socketSecurityWalletDir=$socketSecurityWalletDir
+])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -76,3 +76,11 @@ AC_DEFUN([AX_PROJECT_LOCAL_HOOK_CONFIGVARS], [
     eval socketSecurityWallet=$socketSecurityWallet
     eval socketSecurityWalletDir=$socketSecurityWalletDir
 ])
+
+AC_DEFUN([AX_PROJECT_LOCAL_HOOK_FINAL], [
+    AC_MSG_WARN([Running the PROJECT_LOCAL_HOOK_FINAL])
+
+    AC_CONFIG_FILES([
+        src/fty-security-wallet.conf
+    ])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,10 @@ PKG_PROG_PKG_CONFIG
 # Check endianess of the system
 AC_C_BIGENDIAN
 
+# Optional project-local hook (acinclude.m4, add AC_DEFUN([AX_PROJECT_LOCAL_HOOK], [whatever]) )
+ifdef([AX_PROJECT_LOCAL_HOOK],
+    [AX_PROJECT_LOCAL_HOOK])
+
 # See if cppcheck is in PATH; this variable unblocks the "cppcheck" recipe
 # (note that "make cppcheck.xml" can be used - and perhaps fail - regardless)
 AC_CHECK_PROG([WITH_CPPCHECK], [cppcheck], [true], [false])
@@ -1424,6 +1428,12 @@ AS_IF([test "x$enable_Werror" = "xyes" || test "x$enable_Werror" = "xauto"],
         ])])])
 ])
 
+# Optional project-local hook to (re-)define some variables that can be used
+# in your project files generated from .in templates - in your acinclude.m4,
+# add AC_DEFUN([AX_PROJECT_LOCAL_HOOK_CONFIGVARS], [whatever])
+ifdef([AX_PROJECT_LOCAL_HOOK_CONFIGVARS],
+    [AX_PROJECT_LOCAL_HOOK_CONFIGVARS])
+
 # Specify output files
 AC_CONFIG_FILES([Makefile
                  doc/Makefile
@@ -1438,6 +1448,12 @@ AM_COND_IF([WITH_SYSTEMD_UNITS],
     ])],
     [])
 
+
+# Optional project-local hook to put some finishing touches in your configure
+# script, override something compared to zproject-generated code, etc. - in
+# your acinclude.m4, add AC_DEFUN([AX_PROJECT_LOCAL_HOOK_FINAL], [whatever])
+ifdef([AX_PROJECT_LOCAL_HOOK_FINAL],
+    [AX_PROJECT_LOCAL_HOOK_FINAL])
 
 AC_OUTPUT
 

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -14,6 +14,9 @@ fty-security-wallet.cfg
 # + systemd service unit for daemons (if any):
 fty-security-wallet.service
 
+# + systemd-tmpfiles config:
+fty-security-wallet.conf
+
 # location designated for writing self-tests:
 selftest-rw/
 

--- a/src/fty-security-wallet.cfg.in
+++ b/src/fty-security-wallet.cfg.in
@@ -22,6 +22,6 @@ mapping-malamute
 
 mapping-storage
     database = /var/lib/fty/fty-security-wallet/mapping.json
-    
+
 log
     config = /etc/fty/ftylog.cfg                    # configuration file for fty-common-logging

--- a/src/fty-security-wallet.cfg.in
+++ b/src/fty-security-wallet.cfg.in
@@ -11,7 +11,7 @@ secw-malamute
     address = security-wallet     #   Agent address
 
 secw-socket
-    socket = /run/fty-security-wallet/secw.socket #   Malamute endpoint
+    socket = @socketSecurityWallet@ #   Direct socket endpoint
 
 secw-storage
     database = /var/lib/fty/fty-security-wallet/database.json

--- a/src/fty-security-wallet.conf.in
+++ b/src/fty-security-wallet.conf.in
@@ -1,4 +1,4 @@
 # Create directory for fty-security-wallet
 d /var/lib/fty/fty-security-wallet/ 0700 secw-daemon secw-daemon
-d /run/fty-security-wallet/ 0777 secw-daemon secw-daemon
+d @socketSecurityWalletDir@/ 0777 secw-daemon secw-daemon
 x /var/lib/fty/fty-security-wallet/*

--- a/src/fty-security-wallet.service.in
+++ b/src/fty-security-wallet.service.in
@@ -16,7 +16,7 @@ ExecStart=@prefix@/bin/fty-security-wallet -c @sysconfdir@/@PACKAGE@/fty-securit
 
 # This service is only active, as far as consumers are concerned,
 # after it listens on the Unix socket used to interact with it.
-ExecStartPost=/bin/dash -c "while sleep 0.1; do test -S \"@socketSecurityWallet@\" || continue; PIDS=\"`/bin/fuser \"@socketSecurityWallet@\" 2>/dev/null | sed -e 's,^ *,,' -e 's, *$,,'`\" && [ -n \"$PIDS\" ] || continue ; ( for P in $PIDS ; do ls -la /proc/$P/exe ; done | egrep ' @prefix@/bin/fty-security-wallet$' ) && break ; rePIDS=\"(`echo "$PIDS" | sed 's,  *,|,g'`)\" ; ps -ef | grep -v grep | grep -E \"$rePIDS\" && break ; done; echo 'Socket is being listened'"
+ExecStartPost=/bin/dash -c "while sleep 0.1; do test -S \"@socketSecurityWallet@\" || continue; PIDS=\"`/bin/fuser \"@socketSecurityWallet@\" 2>/dev/null | sed -e 's,^ *,,' -e 's, *$,,'`\" && [ -n \"$PIDS\" ] || continue ; ( for P in $PIDS ; do ls -la /proc/$P/exe ; done | egrep ' @prefix@/bin/fty-security-wallet$' ) && break ; rePIDS=\"(`echo \"$PIDS\" | sed 's,  *,|,g'`)\" ; ps -ef | grep -v grep | grep -E \"$rePIDS\" && break ; done; echo 'Socket is being listened'"
 
 # Last agent out should shut the door cleanly
 ExecStopPost=/bin/dash -c "if [ -z \"`/bin/fuser \"@socketSecurityWallet@\" 2>/dev/null | sed -e 's, *,,g'`\" ] ; then rm -f \"@socketSecurityWallet@\" ; fi"

--- a/src/fty-security-wallet.service.in
+++ b/src/fty-security-wallet.service.in
@@ -16,12 +16,10 @@ ExecStart=@prefix@/bin/fty-security-wallet -c @sysconfdir@/@PACKAGE@/fty-securit
 
 # This service is only active, as far as consumers are concerned,
 # after it listens on the Unix socket used to interact with it.
-# TODO: Set socket path via autoconf and template vars
-### src/fty-security-wallet.cfg.in:    socket = /run/fty-security-wallet/secw.socket #   Malamute endpoint
-ExecStartPost=/bin/dash -c "while sleep 0.1; do test -S /run/fty-security-wallet/secw.socket || continue; PIDS=\"`/bin/fuser /run/fty-security-wallet/secw.socket 2>/dev/null | sed -e 's,^ *,,' -e 's, *$,,'`\" && [ -n \"$PIDS\" ] || continue ; ( for P in $PIDS ; do ls -la /proc/$P/exe ; done | egrep ' @prefix@/bin/fty-security-wallet$' ) && break ; rePIDS=\"(`echo "$PIDS" | sed 's,  *,|,g'`)\" ; ps -ef | grep -v grep | grep -E \"$rePIDS\" && break ; done; echo 'Socket is being listened'"
+ExecStartPost=/bin/dash -c "while sleep 0.1; do test -S \"@socketSecurityWallet@\" || continue; PIDS=\"`/bin/fuser \"@socketSecurityWallet@\" 2>/dev/null | sed -e 's,^ *,,' -e 's, *$,,'`\" && [ -n \"$PIDS\" ] || continue ; ( for P in $PIDS ; do ls -la /proc/$P/exe ; done | egrep ' @prefix@/bin/fty-security-wallet$' ) && break ; rePIDS=\"(`echo "$PIDS" | sed 's,  *,|,g'`)\" ; ps -ef | grep -v grep | grep -E \"$rePIDS\" && break ; done; echo 'Socket is being listened'"
 
 # Last agent out should shut the door cleanly
-ExecStopPost=/bin/dash -c "if [ -z \"`/bin/fuser /run/fty-security-wallet/secw.socket 2>/dev/null | sed -e 's, *,,g'`\" ] ; then rm -f /run/fty-security-wallet/secw.socket ; fi"
+ExecStopPost=/bin/dash -c "if [ -z \"`/bin/fuser \"@socketSecurityWallet@\" 2>/dev/null | sed -e 's, *,,g'`\" ] ; then rm -f \"@socketSecurityWallet@\" ; fi"
 
 Restart=always
 

--- a/src/fty-security-wallet.service.in
+++ b/src/fty-security-wallet.service.in
@@ -13,6 +13,16 @@ EnvironmentFile=-@sysconfdir@/default/fty
 EnvironmentFile=-@sysconfdir@/default/fty__%n.conf
 Environment="prefix=@prefix@"
 ExecStart=@prefix@/bin/fty-security-wallet -c @sysconfdir@/@PACKAGE@/fty-security-wallet.cfg
+
+# This service is only active, as far as consumers are concerned,
+# after it listens on the Unix socket used to interact with it.
+# TODO: Set socket path via autoconf and template vars
+### src/fty-security-wallet.cfg.in:    socket = /run/fty-security-wallet/secw.socket #   Malamute endpoint
+ExecStartPost=/bin/dash -c "while sleep 0.1; do test -S /run/fty-security-wallet/secw.socket || continue; PIDS=\"`/bin/fuser /run/fty-security-wallet/secw.socket 2>/dev/null | sed -e 's,^ *,,' -e 's, *$,,'`\" && [ -n \"$PIDS\" ] || continue ; ( for P in $PIDS ; do ls -la /proc/$P/exe ; done | egrep ' @prefix@/bin/fty-security-wallet$' ) && break ; rePIDS=\"(`echo "$PIDS" | sed 's,  *,|,g'`)\" ; ps -ef | grep -v grep | grep -E \"$rePIDS\" && break ; done; echo 'Socket is being listened'"
+
+# Last agent out should shut the door cleanly
+ExecStopPost=/bin/dash -c "if [ -z \"`/bin/fuser /run/fty-security-wallet/secw.socket 2>/dev/null | sed -e 's, *,,g'`\" ] ; then rm -f /run/fty-security-wallet/secw.socket ; fi"
+
 Restart=always
 
 [Install]


### PR DESCRIPTION
Currently we have a race where systemd forks a secw daemon process, and begins to run a consumer, and by current logic in fty-common-socket it dies if the socket file is not yet usable (not yet listened by secw). Sometimes this race happens in practice and consumer service has to start twice or more.

This PR should declare the service started only after the socket file is connected by the daemon, helping all the consumers start only when it is right to do so.