### PR TITLE
Restore lost execution privileges

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ set(res "resources")
 # 30-secw-update-database-right.sh -> bios/setup
 set(file "30-secw-update-database-right.sh")
 configure_file("${PROJECT_SOURCE_DIR}/${res}/${file}.in" "${PROJECT_BINARY_DIR}/${res}/${file}" @ONLY)
-install(FILES "${PROJECT_BINARY_DIR}/${res}/${file}" DESTINATION ${AGENT_SHARE_BIOS_SETUP_DIR})
+install(PROGRAMS "${PROJECT_BINARY_DIR}/${res}/${file}" DESTINATION ${AGENT_SHARE_BIOS_SETUP_DIR})
 
 # configuration.json -> etc/fty
 set(file "configuration.json")


### PR DESCRIPTION
These were lost over the CMake migration.
install(PROGRAMS...) MUST be used instead of install(FILES...)

Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>